### PR TITLE
Broker config parser should return a parse error if the JSON root type is not an object

### DIFF
--- a/src/core/broker_config.cpp
+++ b/src/core/broker_config.cpp
@@ -494,6 +494,12 @@ void BrokerConfig::SetDefaults()
 // valid.
 BrokerConfig::ParseResult BrokerConfig::ValidateCurrent(etcpal::Logger* log)
 {
+  if (!current_.is_object())
+  {
+    // Root type must be an object
+    return ParseResult::kJsonParseErr;
+  }
+
   ParseResult res = ParseResult::kOk;
 
   for (const auto& setting : kSettingsValidatorArray)  // kSettingsValidatorArray must be iterated first to last

--- a/tests/test_broker_config.cpp
+++ b/tests/test_broker_config.cpp
@@ -149,6 +149,30 @@ TEST_F(TestBrokerConfig, InvalidJsonShouldFailWithoutThrowing)
   }
 }
 
+TEST_F(TestBrokerConfig, InvalidJsonRootTypeShouldFail)
+{
+  // Root types that are not object should generate a parse error. These are types that would be
+  // parsed as valid JSON, but are not valid for the purposes of our config file.
+
+  // clang-format off
+  const std::vector<std::string> kInvalidJsonRootTypes =
+  {
+    "\"foo\"",
+    "42",
+    "[1, 2, 3]",
+    "true",
+    "false",
+    "null",
+  };
+  // clang-format on
+
+  for (const auto& invalid_input : kInvalidJsonRootTypes)
+  {
+    std::istringstream test_stream(invalid_input);
+    EXPECT_EQ(config_.Read(test_stream), BrokerConfig::ParseResult::kJsonParseErr) << "Input tested: " << invalid_input;
+  }
+}
+
 TEST_F(TestBrokerConfig, InvalidCidValueShouldFail)
 {
   // clang-format off


### PR DESCRIPTION
Wayne's efforts to set up the broker service revealed an inconsistency in the code that parses the config file: Invalid JSON such as a trailing comma in an object would be rejected with a parse error, but something that looks like this would be silently replaced with a default config (note the lack of outer braces):

```json
"log_level": "debug",
"enable_broker": true,
// ...
```

This is because the JSON library is pulling that first string from the stream and considering it to be valid JSON. A single JSON element of any type (e.g. string, array, number, boolean) is valid JSON, but of course the broker is only interested in objects. And the `contains()` method when called on a JSON value that is not an object will just always return false. Solution is to check that the parsed JSON is an object.